### PR TITLE
QOL-7970 Fix backwards compatibility

### DIFF
--- a/ckanext/datarequests/controllers/controller_functions.py
+++ b/ckanext/datarequests/controllers/controller_functions.py
@@ -288,17 +288,17 @@ def close(id):
         base_datasets = tk.get_action('package_search')({'ignore_auth': True}, search_data_dict)['results']
 
         log.debug("Dataset candidates for closing data request: %s", base_datasets)
-        dataset_options = []
+        c.datasets = []
         c.errors = errors
         c.errors_summary = errors_summary
         for dataset in base_datasets:
-            dataset_options.append({'name': dataset.get('name'), 'title': dataset.get('title')})
+            c.datasets.append({'name': dataset.get('name'), 'title': dataset.get('title')})
 
         if tk.h.closing_circumstances_enabled:
             # This is required so the form can set the currently selected close_circumstance option in the select dropdown
             c.datarequest['close_circumstance'] = request_helpers.get_first_post_param('close_circumstance', None)
 
-        return tk.render('datarequests/close.html', extra_vars={'datasets': dataset_options})
+        return tk.render('datarequests/close.html')
 
     try:
         tk.check_access(constants.CLOSE_DATAREQUEST, context, data_dict)

--- a/ckanext/datarequests/templates/datarequests/close.html
+++ b/ckanext/datarequests/templates/datarequests/close.html
@@ -10,7 +10,7 @@
 
 {% block primary_content_inner %}
   <h1 class="{% block page_heading_class %}page-heading{% endblock %}">{% block page_heading %}{{ _('Close Data Request') }}{% endblock %}</h1>
-  {% snippet "datarequests/snippets/close_datarequest_form.html", datarequest=c.datarequest, datasets=datasets, errors=c.errors, errors_summary=c.errors_summary  %}
+  {% snippet "datarequests/snippets/close_datarequest_form.html", datarequest=c.datarequest, datasets=c.datasets, errors=c.errors, errors_summary=c.errors_summary  %}
 {% endblock %}
 
 {% block page_header %}{% endblock %}

--- a/ckanext/datarequests/templates/organization/read_base.html
+++ b/ckanext/datarequests/templates/organization/read_base.html
@@ -1,8 +1,8 @@
 {% ckan_extends %}
 
 {% block content_primary_nav %}
-  {% if h.ckan_version()[:3] <= '2.7' %}
-    {% set org_datasets_nav = 'organization_datasets' %}
+  {% if h.ckan_version()[:3] <= '2.8' %}
+    {% set org_datasets_nav = 'organization_read' %}
     {% set org_activity_nav = 'organization_activity' %}
     {% set org_about_nav = 'organization_about' %}
   {% else %}

--- a/ckanext/datarequests/tests/test_ui_controller.py
+++ b/ckanext/datarequests/tests/test_ui_controller.py
@@ -740,6 +740,8 @@ class UIControllerTest(unittest.TestCase):
         self.assertEquals(errors_summary, controller.c.errors_summary)
         self.assertEquals(datarequest, controller.c.datarequest)
 
+        self.assertEquals(expected_datasets, controller.c.datasets)
+
     def test_close_post_no_error(self):
         _patch_POST({'accepted_dataset': 'example_ds'})
 

--- a/ckanext/datarequests/tests/test_ui_controller.py
+++ b/ckanext/datarequests/tests/test_ui_controller.py
@@ -731,7 +731,7 @@ class UIControllerTest(unittest.TestCase):
 
         # Assertions
         expected_datasets = packages
-        controller.tk.render.assert_called_once_with('datarequests/close.html', extra_vars={'datasets': expected_datasets})
+        controller.tk.render.assert_called_once_with('datarequests/close.html')
         self.assertEquals(result, controller.tk.render.return_value)
 
         self.assertIsNone(controller.tk.response.location)


### PR DESCRIPTION
- Revert to `c.datasets` for passing data so we're compatible with the QGOV theme.
- Fix menu items for CKAN 2.8 to keep using Pylons