### PR TITLE
QOL-9055 add Python 3 to CI testing and fix compatibility

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -109,6 +109,13 @@ commands:
       ahoy cli "flake8 ${@:-ckanext}" || \
       [ "${ALLOW_LINT_FAIL:-0}" -eq 1 ]
 
+  copy-local-files:
+    usage: Update files from local repo.
+    cmd: |
+      docker cp . $(docker-compose ps -q ckan):/app/
+      docker cp .docker/scripts/ckan_cli $(docker-compose ps -q ckan):/app/ckan/default/bin/
+      ahoy cli 'chmod u+x $VENV_DIR/bin/ckan_cli; cp .docker/test.ini $CKAN_INI'
+
   test-unit:
     usage: Run unit tests.
     cmd: |
@@ -131,7 +138,7 @@ commands:
     usage: Starts email mock server used for email BDD tests
     cmd: |
       ahoy title 'Starting mailmock'
-      ahoy cli 'mailmock -p 8025 -o ${APP_DIR}/test/emails --no-stdout' # for debugging mailmock email output remove --no-stdout
+      ahoy cli 'mailmock -p 8025 -o ${APP_DIR}/test/emails' # for debugging mailmock email output remove --no-stdout
 
   stop-mailmock:
     usage: Stops email mock server used for email BDD tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
       - run:
           command: .circleci/build.sh
           environment:
-            CKAN_VERSION: 2.9.5
+            CKAN_VERSION: ckan-2.9.5
       - run: .circleci/test.sh
       - run:
           name: Process artifacts

--- a/.docker/Dockerfile-py2.ckan
+++ b/.docker/Dockerfile-py2.ckan
@@ -1,0 +1,47 @@
+FROM amazeeio/python:2.7-ckan-21.8.0
+
+ARG SITE_URL=http://ckan:3000/
+ARG CKAN_REPO=ckan/ckan
+ARG CKAN_VERSION=2.8.8
+ENV SITE_URL="${SITE_URL}"
+ENV VENV_DIR=/app/ckan/default
+ENV APP_DIR=/app
+ENV CKAN_INI=/app/ckan/default/production.ini
+
+WORKDIR "${APP_DIR}"
+
+ENV DOCKERIZE_VERSION v0.6.1
+RUN apk add --no-cache curl build-base postgresql-client \
+    && curl -sLO https://github.com/jwilder/dockerize/releases/download/${DOCKERIZE_VERSION}/dockerize-alpine-linux-amd64-${DOCKERIZE_VERSION}.tar.gz \
+    && tar -C /usr/local/bin -xzvf dockerize-alpine-linux-amd64-${DOCKERIZE_VERSION}.tar.gz \
+    && rm dockerize-alpine-linux-amd64-${DOCKERIZE_VERSION}.tar.gz
+
+# Install CKAN.
+
+RUN . ${VENV_DIR}/bin/activate \
+    && pip install setuptools==36.1 \
+    && pip install -e "git+https://github.com/${CKAN_REPO}.git@ckan-${CKAN_VERSION}#egg=ckan" \
+    && sed -i "s/psycopg2==2.4.5/psycopg2==2.7.7/g" "${VENV_DIR}/src/ckan/requirements.txt" \
+    && ((test -f "${VENV_DIR}/src/ckan/requirements-py2.txt" && \
+        pip install -r "${VENV_DIR}/src/ckan/requirements-py2.txt") || \
+        pip install -r "${VENV_DIR}/src/ckan/requirements.txt") \
+    && ln -s "${VENV_DIR}/src/ckan/who.ini" "${VENV_DIR}/who.ini" \
+    && deactivate \
+    && ln -s ${APP_DIR}/ckan /usr/lib/ckan \
+    && fix-permissions ${APP_DIR}/ckan
+
+COPY .docker/test.ini $CKAN_INI
+
+COPY . ${APP_DIR}/
+
+COPY .docker/scripts ${APP_DIR}/scripts
+
+COPY .docker/scripts/ckan_cli ${VENV_DIR}/bin/
+
+RUN chmod +x ${APP_DIR}/scripts/*.sh ${VENV_DIR}/bin/ckan_cli
+
+# Init current extension.
+RUN ${APP_DIR}/scripts/init-ext.sh
+
+ENTRYPOINT ["/sbin/tini", "--", "/lagoon/entrypoints.sh"]
+CMD ["/app/scripts/serve.sh"]

--- a/.docker/Dockerfile-py2.ckan
+++ b/.docker/Dockerfile-py2.ckan
@@ -2,7 +2,7 @@ FROM amazeeio/python:2.7-ckan-21.8.0
 
 ARG SITE_URL=http://ckan:3000/
 ARG CKAN_REPO=ckan/ckan
-ARG CKAN_VERSION=2.8.8
+ARG CKAN_VERSION=ckan-2.8.8
 ENV SITE_URL="${SITE_URL}"
 ENV VENV_DIR=/app/ckan/default
 ENV APP_DIR=/app
@@ -20,7 +20,7 @@ RUN apk add --no-cache curl build-base postgresql-client \
 
 RUN . ${VENV_DIR}/bin/activate \
     && pip install setuptools==36.1 \
-    && pip install -e "git+https://github.com/${CKAN_REPO}.git@ckan-${CKAN_VERSION}#egg=ckan" \
+    && pip install -e "git+https://github.com/${CKAN_REPO}.git@${CKAN_VERSION}#egg=ckan" \
     && sed -i "s/psycopg2==2.4.5/psycopg2==2.7.7/g" "${VENV_DIR}/src/ckan/requirements.txt" \
     && ((test -f "${VENV_DIR}/src/ckan/requirements-py2.txt" && \
         pip install -r "${VENV_DIR}/src/ckan/requirements-py2.txt") || \

--- a/.docker/Dockerfile-py3.ckan
+++ b/.docker/Dockerfile-py3.ckan
@@ -1,8 +1,8 @@
-FROM amazeeio/python:2.7-ckan-21.8.0
+FROM amazeeio/python:3.8-22.7.0
 
 ARG SITE_URL=http://ckan:3000/
 ARG CKAN_REPO=ckan/ckan
-ARG CKAN_VERSION=2.8.8
+ARG CKAN_VERSION=ckan-2.9.5
 ENV SITE_URL="${SITE_URL}"
 ENV VENV_DIR=/app/ckan/default
 ENV APP_DIR=/app
@@ -11,20 +11,19 @@ ENV CKAN_INI=/app/ckan/default/production.ini
 WORKDIR "${APP_DIR}"
 
 ENV DOCKERIZE_VERSION v0.6.1
-RUN apk add --no-cache curl build-base \
+RUN apk add --no-cache curl build-base git libxml2-dev libxslt-dev postgresql postgresql-client postgresql-dev \
     && curl -sLO https://github.com/jwilder/dockerize/releases/download/${DOCKERIZE_VERSION}/dockerize-alpine-linux-amd64-${DOCKERIZE_VERSION}.tar.gz \
     && tar -C /usr/local/bin -xzvf dockerize-alpine-linux-amd64-${DOCKERIZE_VERSION}.tar.gz \
     && rm dockerize-alpine-linux-amd64-${DOCKERIZE_VERSION}.tar.gz
 
 # Install CKAN.
 
-RUN . ${VENV_DIR}/bin/activate \
-    && pip install setuptools==36.1 \
-    && pip install -e "git+https://github.com/${CKAN_REPO}.git@ckan-${CKAN_VERSION}#egg=ckan" \
-    && sed -i "s/psycopg2==2.4.5/psycopg2==2.7.7/g" "${VENV_DIR}/src/ckan/requirements.txt" \
-    && ((test -f "${VENV_DIR}/src/ckan/requirements-py2.txt" && \
-        pip install -r "${VENV_DIR}/src/ckan/requirements-py2.txt") || \
-        pip install -r "${VENV_DIR}/src/ckan/requirements.txt") \
+RUN mkdir -p ${VENV_DIR} \
+    && virtualenv ${VENV_DIR} \
+    && . ${VENV_DIR}/bin/activate \
+    && pip install setuptools==44.1.0 \
+    && pip install -e "git+https://github.com/${CKAN_REPO}.git@${CKAN_VERSION}#egg=ckan" \
+    && pip install -r "${VENV_DIR}/src/ckan/requirements.txt" \
     && ln -s "${VENV_DIR}/src/ckan/who.ini" "${VENV_DIR}/who.ini" \
     && deactivate \
     && ln -s ${APP_DIR}/ckan /usr/lib/ckan \

--- a/.docker/scripts/ckan_cli
+++ b/.docker/scripts/ckan_cli
@@ -57,15 +57,15 @@ else
 fi
 
 if [ "$COMMAND" = "ckan" ]; then
-    echo "Using 'ckan' command from $ENV_DIR with config ${CKAN_INI}..." >&2
     # adjust args to match ckan expectations
     COMMAND=$(echo "$1" | sed -e 's/create-test-data/seed/')
+    echo "Using 'ckan' command from $ENV_DIR with config ${CKAN_INI} to run $COMMAND..." >&2
     shift
     exec $ENV_DIR/ckan -c ${CKAN_INI} $COMMAND "$@" $CLICK_ARGS
 elif [ "$COMMAND" = "paster" ]; then
-    echo "Using 'paster' command from $ENV_DIR with config ${CKAN_INI}..." >&2
     # adjust args to match paster expectations
     COMMAND=$1
+    echo "Using 'paster' command from $ENV_DIR with config ${CKAN_INI} to run $COMMAND..." >&2
     shift
     if [ "$1" = "show" ]; then shift; fi
     exec $ENV_DIR/paster --plugin=$PASTER_PLUGIN $COMMAND "$@" -c ${CKAN_INI}

--- a/.docker/scripts/create-test-data.sh
+++ b/.docker/scripts/create-test-data.sh
@@ -4,15 +4,14 @@
 #
 set -e
 
+CKAN_USER_NAME="${CKAN_USER_NAME:-admin}"
+CKAN_DISPLAY_NAME="${CKAN_DISPLAY_NAME:-Administrator}"
+CKAN_USER_EMAIL="${CKAN_USER_EMAIL:-admin@localhost}"
 CKAN_ACTION_URL=http://ckan:3000/api/action
 
 if [ "$VENV_DIR" != "" ]; then
   . ${VENV_DIR}/bin/activate
 fi
-
-CKAN_USER_NAME="${CKAN_USER_NAME:-admin}"
-CKAN_DISPLAY_NAME="${CKAN_DISPLAY_NAME:-Administrator}"
-CKAN_USER_EMAIL="${CKAN_USER_EMAIL:-admin@localhost}"
 
 add_user_if_needed () {
     echo "Adding user '$2' ($1) with email address [$3]"
@@ -25,7 +24,6 @@ add_user_if_needed () {
 add_user_if_needed "$CKAN_USER_NAME" "$CKAN_DISPLAY_NAME" "$CKAN_USER_EMAIL"
 ckan_cli sysadmin add "${CKAN_USER_NAME}"
 
-# We know the "admin" sysadmin account exists, so we'll use her API KEY to create further data
 API_KEY=$(ckan_cli user show "${CKAN_USER_NAME}" | tr -d '\n' | sed -r 's/^(.*)apikey=(\S*)(.*)/\2/')
 if [ "$API_KEY" = "None" ]; then
     echo "No API Key found on ${CKAN_USER_NAME}, generating API Token..."
@@ -68,9 +66,9 @@ TEST_ORG=$( \
     ${CKAN_ACTION_URL}/organization_create
 )
 
-TEST_ORG_ID=$(echo $TEST_ORG | sed -r 's/^(.*)"id": "(.*)",(.*)/\2/')
+TEST_ORG_ID=$(echo $TEST_ORG | sed -r 's/^(.*)"id": "([^"]*)",(.*)/\2/')
 
-echo "Assigning test users to ${TEST_ORG_TITLE} Organisation:"
+echo "Assigning test users to '${TEST_ORG_TITLE}' organisation (${TEST_ORG_ID}):"
 
 curl -LsH "Authorization: ${API_KEY}" \
     --data "id=${TEST_ORG_ID}&object=test_org_admin&object_type=user&capacity=admin" \
@@ -108,7 +106,7 @@ DR_ORG=$( \
     ${CKAN_ACTION_URL}/organization_create
 )
 
-DR_ORG_ID=$(echo $DR_ORG | sed -r 's/^(.*)"id": "(.*)",(.*)/\2/')
+DR_ORG_ID=$(echo $DR_ORG | sed -r 's/^(.*)"id": "([^"]*)",(.*)/\2/')
 
 echo "Assigning test users to ${DR_ORG_TITLE} Organisation:"
 

--- a/.docker/scripts/init.sh
+++ b/.docker/scripts/init.sh
@@ -11,11 +11,5 @@ CLICK_ARGS="--yes" ckan_cli db clean
 ckan_cli db init
 ckan_cli db upgrade
 
-CKAN_USER_NAME="${CKAN_USER_NAME:-admin}"
-CKAN_DISPLAY_NAME="${CKAN_DISPLAY_NAME:-Administrator}"
-CKAN_USER_EMAIL="${CKAN_USER_EMAIL:-admin@localhost}"
-CKAN_USER_PASSWORD="${CKAN_USER_PASSWORD:-Password123!}"
-ckan_cli user add "$CKAN_USER_NAME" fullname="$CKAN_DISPLAY_NAME" email="$CKAN_USER_EMAIL" password="$CKAN_USER_PASSWORD"
-
 # Create some base test data
 . $APP_DIR/scripts/create-test-data.sh

--- a/.docker/scripts/serve.sh
+++ b/.docker/scripts/serve.sh
@@ -11,7 +11,7 @@ if [ "$VENV_DIR" != "" ]; then
   . ${VENV_DIR}/bin/activate
 fi
 if (which ckan > /dev/null); then
-    ckan -c ${CKAN_INI} run
+    ckan -c ${CKAN_INI} run -r
 else
     paster serve ${CKAN_INI}
 fi

--- a/.docker/test.ini
+++ b/.docker/test.ini
@@ -97,7 +97,7 @@ ckan.redis.url = redis://redis:6379
 #       Add ``datapusher`` to enable DataPusher
 #       Add ``resource_proxy`` to enable resource proxying and get around the
 #       same origin policy
-ckan.plugins = stats text_view image_view recline_view datastore datarequests
+ckan.plugins = stats text_view image_view recline_view datarequests
 
 # Define which views should be created by default
 # (plugins must be loaded in ckan.plugins)
@@ -154,16 +154,18 @@ ckan.hide_activity_from_users = %(ckan.site_id)s
 
 
 ## Email settings
+
+#email_to = errors@example.com
+#error_email_from = ckan-errors@example.com
+#smtp.server = localhost
+#smtp.starttls = False
+#smtp.user = username@example.com
+#smtp.password = your_password
+#smtp.mail_from =
 # If 'smtp.test_server' is configured we assume we're running tests,
 # and don't use the smtp.server, starttls, user, password etc. options.
 smtp.test_server = localhost:8025
 smtp.mail_from = info@test.ckan.net
-
-## Harvester settings
-ckan.harvest.mq.type = redis
-ckan.harvest.mq.hostname = redis
-ckan.harvest.mq.port = 6379
-ckan.harvest.mq.redis_db = 0
 
 ## ckanext-datarequests settings
 # Enable or disable the comments system by setting up the ckan.datarequests.comments property in the configuration file (by default, the comments system is enabled).

--- a/.flake8
+++ b/.flake8
@@ -12,6 +12,7 @@ format = pylint
 show_source = True
 
 max-complexity = 10
+max-line-length = 127
 
 # List ignore rules one per line.
 ignore =

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,10 +11,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ckan-version: [2.8.8, 2.9.5]
+        ckan-version: [ckan-2.8.8, ckan-2.9.5]
         python-version: [py2, py3]
         exclude:
-          - ckan-version: 2.8.8
+          - ckan-version: ckan-2.8.8
             python-version: py3
 
     name: Continuous Integration build on CKAN ${{ matrix.ckan-version }} ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,13 +12,18 @@ jobs:
       fail-fast: false
       matrix:
         ckan-version: [2.8.8, 2.9.5]
+        python-version: [py2, py3]
+        exclude:
+          - ckan-version: 2.8.8
+            python-version: py3
 
-    name: Continuous Integration build on CKAN ${{ matrix.ckan-version }}
+    name: Continuous Integration build on CKAN ${{ matrix.ckan-version }} ${{ matrix.python-version }}
     runs-on: ubuntu-latest
     container: integratedexperts/ci-builder
     env:
       CKAN_REPO: ckan/ckan
       CKAN_VERSION: ${{ matrix.ckan-version }}
+      PYTHON_VERSION: ${{ matrix.python-version }}
 
     steps:
       - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,13 @@ env/
 build/
 develop-eggs/
 dist/
+downloads/
+eggs/
+lib/
+lib64/
+parts/
 sdist/
+var/
 *.egg-info/
 .installed.cfg
 *.egg
@@ -38,6 +44,7 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
+test/screenshots
 
 # Translations
 *.mo
@@ -51,4 +58,9 @@ docs/_build/
 .env.local
 screenshots
 !/test/screenshots/.gitkeep
+
+# PyBuilder
+target/
+
+#Intellij
 .idea

--- a/ckanext/datarequests/actions.py
+++ b/ckanext/datarequests/actions.py
@@ -19,7 +19,7 @@
 
 
 import datetime
-import cgi
+from html import escape
 import logging
 
 from ckan import model
@@ -132,7 +132,7 @@ def _dictize_comment(comment):
 
 
 def _undictize_comment_basic(comment, data_dict):
-    comment.comment = cgi.escape(data_dict.get('comment', ''))
+    comment.comment = escape(data_dict.get('comment', ''))
     comment.datarequest_id = data_dict.get('datarequest_id', '')
 
 

--- a/ckanext/datarequests/actions.py
+++ b/ckanext/datarequests/actions.py
@@ -19,8 +19,11 @@
 
 
 import datetime
-from html import escape
 import logging
+try:
+    from html import escape
+except ImportError:
+    from cgi import escape
 
 from ckan import model
 from ckan.lib import mailer

--- a/ckanext/datarequests/controllers/controller_functions.py
+++ b/ckanext/datarequests/controllers/controller_functions.py
@@ -416,11 +416,11 @@ def delete_comment(datarequest_id, comment_id):
         return tk.abort(403, tk._('You are not authorized to delete this comment'))
 
 
-def follow(datarequest_id):
+def follow(id):
     # Method is not called
     pass
 
 
-def unfollow(datarequest_id):
+def unfollow(id):
     # Method is not called
     pass

--- a/ckanext/datarequests/fanstatic/webassets.yml
+++ b/ckanext/datarequests/fanstatic/webassets.yml
@@ -1,0 +1,15 @@
+edit_comments-js:
+  contents:
+    - edit_comment.js
+  output: datarequest/%(version)s_edit_comment.js
+  extra:
+    preload:
+      - vendor/jquery
+
+datarequest_close-js:
+  contents:
+    - datarequest_close.js
+  output: datarequest/%(version)s_datarequest_close.js
+  extra:
+    preload:
+      - vendor/jquery

--- a/ckanext/datarequests/fanstatic/webassets.yml
+++ b/ckanext/datarequests/fanstatic/webassets.yml
@@ -1,3 +1,5 @@
+# See https://docs.ckan.org/en/2.9/contributing/frontend/assets.html
+
 edit_comments-js:
   contents:
     - edit_comment.js

--- a/ckanext/datarequests/helpers.py
+++ b/ckanext/datarequests/helpers.py
@@ -42,7 +42,7 @@ def get_open_datarequests_number():
 
 
 def is_following_datarequest(datarequest_id):
-    # DB should be intialized
+    # DB should be initialized
     db.init_db(model)
     return len(db.DataRequestFollower.get(datarequest_id=datarequest_id, user_id=c.userobj.id)) > 0
 

--- a/ckanext/datarequests/plugin/flask_plugin.py
+++ b/ckanext/datarequests/plugin/flask_plugin.py
@@ -54,13 +54,13 @@ class MixinPlugin(p.SingletonPlugin):
                 ('GET', 'POST',),
             ),
             (
-                "/{}/follow/<datarequest_id>".format(constants.DATAREQUESTS_MAIN_PATH),
+                "/{}/follow/<id>".format(constants.DATAREQUESTS_MAIN_PATH),
                 "follow",
                 controller_functions.follow,
                 ('POST',),
             ),
             (
-                "/{}/unfollow/<datarequest_id>".format(constants.DATAREQUESTS_MAIN_PATH),
+                "/{}/unfollow/<id>".format(constants.DATAREQUESTS_MAIN_PATH),
                 "unfollow",
                 controller_functions.unfollow,
                 ('POST',),

--- a/ckanext/datarequests/templates/datarequests/snippets/additional_info.html
+++ b/ckanext/datarequests/templates/datarequests/snippets/additional_info.html
@@ -1,3 +1,4 @@
+{% set dataset_read_route = 'dataset.read' if h.ckan_version() > '2.9' else 'dataset_read' %}
 <section class="additional-info">
   <h3>{{ _('Additional Info') }}</h3>
   <table class="table table-striped table-bordered table-condensed">
@@ -39,7 +40,7 @@
               <tr>
                 <th scope="row" class="dataset-label">{{ _('Accepted dataset') }}</th>
                 <td class="dataset-details">
-                  {% link_for datarequest.accepted_dataset['title'], named_route='package.read', id=datarequest.accepted_dataset.get('id') %}
+                  {% link_for datarequest.accepted_dataset['title'], named_route=dataset_read_route, id=datarequest.accepted_dataset.get('id') %}
                 </td>
               </tr>
             {% endif %}
@@ -48,7 +49,7 @@
               <th scope="row" class="dataset-label">{{ _('Accepted dataset') }}</th>
               <td class="dataset-details">
               {% if datarequest.accepted_dataset %}
-                {% link_for datarequest.accepted_dataset['title'], named_route='package.read', id=datarequest.accepted_dataset.get('id') %}
+                {% link_for datarequest.accepted_dataset['title'], named_route=dataset_read_route, id=datarequest.accepted_dataset.get('id') %}
               {% else %}
                 {{ _('None') }}
               {% endif %}

--- a/ckanext/datarequests/templates/datarequests/snippets/close_datarequest_form.html
+++ b/ckanext/datarequests/templates/datarequests/snippets/close_datarequest_form.html
@@ -9,7 +9,11 @@
 
   {% block closing_circumstance %}
     {% if h.closing_circumstances_enabled %}
-        {% resource 'datarequest/datarequest_close.js' %}
+        {% if h.ckan_version() > '2.9' %}
+            {% snippet "snippets/datarequest_close_asset.html" %}
+        {% else %}
+            {% snippet "snippets/datarequest_close_resource.html" %}
+        {% endif %}
         {% set close_circumstances = h.get_closing_circumstances() %}
         {% set selected_close_circumstance = datarequest.get('close_circumstance', '') %}
 

--- a/ckanext/datarequests/templates/datarequests/snippets/comment_form.html
+++ b/ckanext/datarequests/templates/datarequests/snippets/comment_form.html
@@ -1,5 +1,10 @@
 {% import 'macros/form.html' as form %}
-{% resource "datarequest/edit_comment.js" %}
+
+{% if h.ckan_version() > '2.9' %}
+    {% snippet "snippets/edit_comment_asset.html" %}
+{% else %}
+    {% snippet "snippets/edit_comment_resource.html" %}
+{% endif %}
 
 <form class="dataset-form {{ 'comment-edit-form' if comment_id else 'comment-wrapper' }} {{ 'hide' if comment_id and not (focus and errors) }} form-horizontal" id="comment-form{{ '-' + comment_id if comment_id }}" method="post" data-module="basic-form" action enctype="multipart/form-data">
 
@@ -18,7 +23,7 @@
   <input type="hidden" name="comment-id" value="{{ comment_id if comment_id }}" />
 
   <div class="control-full control-large control-group {{ 'error' if errors and errors.get('Comment') and focus }} editor">
-    {% set markdown_tooltip = "<pre><p>__Bold text__ or _italic text_</p><p># title<br>## secondary title<br>### etc</p><p>* list<br>* of<br>* items</p><p>http://auto.link.ed/</p></pre><p><b><a href='http://daringfireball.net/projects/markdown/syntax' target='_blank'>Full markdown syntax</a></b></p><p class='muted'><b>Please note:</b> HTML tags are stripped out for security reasons</p>" %} 
+    {% set markdown_tooltip = "<pre><p>__Bold text__ or _italic text_</p><p># title<br>## secondary title<br>### etc</p><p>* list<br>* of<br>* items</p><p>http://auto.link.ed/</p></pre><p><b><a href='http://daringfireball.net/projects/markdown/syntax' target='_blank'>Full markdown syntax</a></b></p><p class='muted'><b>Please note:</b> HTML tags are stripped out for security reasons</p>" %}
     <textarea class="form-control" name="comment" cols="20" rows="3" placeholder="{{ _('Add a new Comment') if not comment_id }}">{{ initial_text }}</textarea>
     <span class="editor-info-block">{% trans %}You can use <a href="#markdown" title="Markdown quick reference" data-target="popover" data-content="{{ markdown_tooltip }}" data-html="true">Markdown formatting</a> here. You can refer datasets by adding their URL.{% endtrans %}</span>
   </div>

--- a/ckanext/datarequests/templates/snippets/datarequest_close_asset.html
+++ b/ckanext/datarequests/templates/snippets/datarequest_close_asset.html
@@ -1,0 +1,1 @@
+{% asset 'datarequest/datarequest_close-js' %}

--- a/ckanext/datarequests/templates/snippets/datarequest_close_resource.html
+++ b/ckanext/datarequests/templates/snippets/datarequest_close_resource.html
@@ -1,0 +1,1 @@
+{% resource 'datarequest/datarequest_close.js' %}

--- a/ckanext/datarequests/templates/snippets/edit_comment_asset.html
+++ b/ckanext/datarequests/templates/snippets/edit_comment_asset.html
@@ -1,0 +1,1 @@
+{% asset "datarequest/edit_comment-js" %}

--- a/ckanext/datarequests/templates/snippets/edit_comment_resource.html
+++ b/ckanext/datarequests/templates/snippets/edit_comment_resource.html
@@ -1,0 +1,1 @@
+{% resource "datarequest/edit_comment.js" %}

--- a/ckanext/datarequests/tests/test_helpers.py
+++ b/ckanext/datarequests/tests/test_helpers.py
@@ -35,14 +35,15 @@ class HelpersTest(unittest.TestCase):
         self.db_patch = patch('ckanext.datarequests.helpers.db')
         self.db_patch.start()
 
-        self.c_patch = patch('ckanext.datarequests.helpers.c')
-        self.c = self.c_patch.start()
+        self._c = helpers.c
+        helpers.c = MagicMock()
+        helpers.c.userobj.id = '12345'
 
     def tearDown(self):
         self.tk_patch.stop()
         self.model_patch.stop()
         self.db_patch.stop()
-        self.c_patch.stop()
+        helpers.c = self._c
 
     def test_get_comments_number(self):
         # Mocking
@@ -112,7 +113,7 @@ class HelpersTest(unittest.TestCase):
 
         self.assertTrue(helpers.is_following_datarequest(datarequest_id))
 
-        helpers.db.DataRequestFollower.get.assert_called_once_with(datarequest_id=datarequest_id, user_id=self.c.userobj.id)
+        helpers.db.DataRequestFollower.get.assert_called_once_with(datarequest_id=datarequest_id, user_id='12345')
 
     def test_is_following_datarequest_false(self):
         datarequest_id = 'example_id'
@@ -120,4 +121,4 @@ class HelpersTest(unittest.TestCase):
 
         self.assertFalse(helpers.is_following_datarequest(datarequest_id))
 
-        helpers.db.DataRequestFollower.get.assert_called_once_with(datarequest_id=datarequest_id, user_id=self.c.userobj.id)
+        helpers.db.DataRequestFollower.get.assert_called_once_with(datarequest_id=datarequest_id, user_id='12345')

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
   ckan:
     build:
       context: .
-      dockerfile: .docker/Dockerfile.ckan
+      dockerfile: .docker/Dockerfile-${PYTHON_VERSION}.ckan
       args:
         SITE_URL: "http://${PROJECT}.docker.amazee.io"
         CKAN_REPO:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,16 +52,6 @@ services:
     environment:
       <<: *default-environment
 
-  postgres-datastore:
-    image: amazeeio/postgres-ckan
-    ports:
-      - "5432"
-    networks:
-      - amazeeio-network
-      - default
-    environment:
-      <<: *default-environment
-
   redis:
     image: redis:6-alpine
     environment:

--- a/test/features/homepage.feature
+++ b/test/features/homepage.feature
@@ -2,6 +2,7 @@
 Feature: Homepage
 
     @homepage
+    @unauthenticated
     Scenario: Smoke test to ensure Homepage is accessible
+        Given "Unauthenticated" as the persona
         When I go to homepage
-

--- a/test/features/steps/steps.py
+++ b/test/features/steps/steps.py
@@ -133,7 +133,7 @@ def submit_reply_with_comment(context, comment):
 
 
 # The default behaving step does not convert base64 emails
-# Modifed the default step to decode the payload from base64
+# Modified the default step to decode the payload from base64
 @step(u'I should receive a base64 email at "{address}" containing "{text}"')
 def should_receive_base64_email_containing_text(context, address, text):
     def filter_contents(mail):


### PR DESCRIPTION
- Add Github Actions run for Python 3
- Replace Fanstatic with Webassets on CKAN 2.9+
- Replace deprecated 'cgi.escape' if 'html.escape' is available
- Fix Flask routing for dataset reads