### PR TITLE
QOLDEV-455 enable reCAPTCHA on datarequest comment and new data request forms

### DIFF
--- a/ckanext/datarequests/templates/datarequests/snippets/comment_form.html
+++ b/ckanext/datarequests/templates/datarequests/snippets/comment_form.html
@@ -25,6 +25,10 @@
     <span class="editor-info-block">{% trans %}You can use <a href="#markdown" title="Markdown quick reference" data-target="popover" data-content="{{ markdown_tooltip }}" data-html="true">Markdown formatting</a> here. You can refer datasets by adding their URL.{% endtrans %}</span>
   </div>
 
+  {% if g.recaptcha_publickey %}
+    {% snippet "user/snippets/recaptcha.html", public_key=g.recaptcha_publickey %}
+  {% endif %}
+
   <div class="comment-form-actions">
     {% if comment_id %}
       <button id="comment-discard-{{ comment_id }}" class="btn btn-danger" name="discard">{{ _('Cancel') }}</button>

--- a/ckanext/datarequests/templates/datarequests/snippets/datarequest_form.html
+++ b/ckanext/datarequests/templates/datarequests/snippets/datarequest_form.html
@@ -40,6 +40,10 @@ then itself be extended to add/remove blocks of functionality. #}
   </div>
   {% endblock %}
 
+  {% if g.recaptcha_publickey %}
+    {% snippet "user/snippets/recaptcha.html", public_key=g.recaptcha_publickey %}
+  {% endif %}
+
   {% block form_actions %}
     <div class="form-actions">
       {% block delete_button %}


### PR DESCRIPTION
enable default ckan recaptcha if public/private keys are in config.
you can display recaptcha and skip verifiying by not enabling private key (for e2e automated testing)