### PR TITLE
QOLSVC-3443 add profanity filter on data requests and comments

### DIFF
--- a/.docker/test.ini
+++ b/.docker/test.ini
@@ -179,6 +179,9 @@ ckan.datarequests.default_organisation = open-data-administration-data-requests
 # Enable or disable circumstances for closing data requests. Default value is False
 ckan.datarequests.enable_closing_circumstances = True
 
+ckan.comments.check_for_profanity = True
+ckan.comments.bad_words_file = /srv/app/ckanext/datarequests/bad_words.txt
+
 # Logging configuration
 [loggers]
 keys = root, ckan, ckanext

--- a/ckanext/datarequests/bad_words.txt
+++ b/ckanext/datarequests/bad_words.txt
@@ -1,0 +1,4 @@
+ass
+asses
+piss
+zoophilia

--- a/ckanext/datarequests/templates/datarequests/snippets/comments.html
+++ b/ckanext/datarequests/templates/datarequests/snippets/comments.html
@@ -1,8 +1,14 @@
+{% import 'macros/form.html' as form %}
+
 <h2 class="page-heading">
   {% block page_heading %}
     {{ _('Current Discussion') }}
   {% endblock %}
 </h2>
+
+{% if c.errors_summary %}
+{{ form.errors(c.errors_summary) }}
+{% endif %}
 
 {% if comments %}
   {% for comment in comments %}

--- a/ckanext/datarequests/validator.py
+++ b/ckanext/datarequests/validator.py
@@ -117,13 +117,18 @@ def validate_comment(context, request_data):
     except Exception:
         raise tk.ValidationError({tk._('Data Request'): [tk._('Data Request not found')]})
 
+    errors = {}
+    comment_field = tk._('Comment')
     if not comment or len(comment) <= 0:
-        raise tk.ValidationError({tk._('Comment'): [tk._('Comments must be a minimum of 1 character long')]})
+        _add_error(errors, comment_field, tk._('Comments must be a minimum of 1 character long'))
 
     if len(comment) > constants.COMMENT_MAX_LENGTH:
-        raise tk.ValidationError({tk._('Comment'): [tk._('Comments must be a maximum of %d characters long') % constants.COMMENT_MAX_LENGTH]})
+        _add_error(errors, comment_field, tk._('Comments must be a maximum of %d characters long') % constants.COMMENT_MAX_LENGTH)
 
     if profanity_check_enabled() and common.profanity_check(comment):
-        raise tk.ValidationError({"message": "Comment blocked due to profanity."})
+        _add_error(errors, comment_field, tk._("Comment blocked due to profanity."))
+
+    if errors:
+        raise tk.ValidationError(errors)
 
     return datarequest

--- a/ckanext/datarequests/validator.py
+++ b/ckanext/datarequests/validator.py
@@ -31,14 +31,8 @@ def validate_datarequest(context, request_data):
 
     errors = {}
 
-    # Run profanity check
-    title = request_data['title']
-    description = request_data['description']
-    if profanity_check_enabled() \
-            and (common.profanity_check(title) or common.profanity_check(description)):
-        raise tk.ValidationError({"message": "Request blocked due to profanity."})
-
     # Check name
+    title = request_data['title']
     title_field = tk._('Title')
     if len(title) > constants.NAME_MAX_LENGTH:
         errors[title_field] = [tk._('Title must be a maximum of %d characters long') % constants.NAME_MAX_LENGTH]
@@ -54,12 +48,20 @@ def validate_datarequest(context, request_data):
             errors[title_field] = [tk._('That title is already in use')]
 
     # Check description
+    description = request_data['description']
     description_field = tk._('Description')
     if common.get_config_bool_value('ckan.datarequests.description_required', False) and not description:
         errors[description_field] = [tk._('Description cannot be empty')]
 
     if len(description) > constants.DESCRIPTION_MAX_LENGTH:
         errors[description_field] = [tk._('Description must be a maximum of %d characters long') % constants.DESCRIPTION_MAX_LENGTH]
+
+    # Run profanity check
+    if profanity_check_enabled():
+        if title_field not in errors and common.profanity_check(title):
+            errors[title_field] = tk._("Blocked due to profanity")
+        if description_field not in errors and common.profanity_check(description):
+            errors[description_field] = tk._("Blocked due to profanity")
 
     # Check organization
     if request_data['organization_id']:

--- a/dev-requirements-py2.txt
+++ b/dev-requirements-py2.txt
@@ -8,6 +8,7 @@ flake8==3.8.3
 messytables==0.15.2
 mock
 parameterized==0.8.1
+profanityfilter
 progressbar==2.5
 pytest-ckan
 python-magic==0.4.18

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,6 +7,7 @@ flake8==3.8.3
 messytables==0.15.2
 mock
 parameterized==0.8.1
+profanityfilter
 progressbar==2.5
 pytest-ckan
 python-magic==0.4.18

--- a/test/features/comments.feature
+++ b/test/features/comments.feature
@@ -27,6 +27,5 @@ Feature: Comments
         When I log in
         And I create a datarequest
         And I go to data request "$last_generated_title" comments
-        Then I should see an element with xpath "//h3[contains(string(), 'Add a comment')]"
-        When I submit a comment with subject "Test subject" and comment "He had sheep, and oxen, and he asses, and menservants, and maidservants, and she asses, and camels."
+        And I submit a comment with subject "Test subject" and comment "He had sheep, and oxen, and he asses, and menservants, and maidservants, and she asses, and camels."
         Then I should see "Comment blocked due to profanity" within 5 seconds

--- a/test/features/comments.feature
+++ b/test/features/comments.feature
@@ -20,3 +20,13 @@ Feature: Comments
         Then I should see "Are you sure you want to delete this comment?" within 1 seconds
         When I press the element with xpath "//button[contains(string(), 'Confirm')]"
         Then I should see "Comment has been deleted" within 2 seconds
+
+    @comment-add @comment-profane @datarequest
+    Scenario: When a logged-in user submits a comment containing profanity on a Data Request they should receive an error message and the comment will not appear
+        Given "CKANUser" as the persona
+        When I log in
+        And I create a datarequest
+        And I go to data request "$last_generated_title" comments
+        Then I should see an element with xpath "//h3[contains(string(), 'Add a comment')]"
+        When I submit a comment with subject "Test subject" and comment "He had sheep, and oxen, and he asses, and menservants, and maidservants, and she asses, and camels."
+        Then I should see "Comment blocked due to profanity" within 5 seconds

--- a/test/features/datarequest.feature
+++ b/test/features/datarequest.feature
@@ -61,7 +61,7 @@ Feature: Datarequest
         And I fill in title with random text
         And I fill in "description" with "He had sheep, and oxen, and he asses, and menservants, and maidservants, and she asses, and camels."
         And I press the element with xpath "//button[contains(@class, 'btn-primary') and contains(string(), 'Create Data Request')]"
-        Then I should see "Request blocked due to profanity" within 5 seconds
+        Then I should see "Blocked due to profanity" within 5 seconds
 
     Scenario Outline: Data request creator and Sysadmin can see a 'Close' button on the data request detail page for opened data requests
         Given "<User>" as the persona

--- a/test/features/datarequest.feature
+++ b/test/features/datarequest.feature
@@ -53,6 +53,16 @@ Feature: Datarequest
         And I should see an element with the css selector "span.error-block" within 1 seconds
         And I should see "Description cannot be empty" within 1 seconds
 
+    Scenario: When a logged-in user submits a Data Request containing profanity they should receive an error message and the request will not be created
+        Given "CKANUser" as the persona
+        When I log in
+        And I go to the data requests page
+        And I press "Add Data Request"
+        And I fill in title with random text
+        And I fill in "description" with "He had sheep, and oxen, and he asses, and menservants, and maidservants, and she asses, and camels."
+        And I press the element with xpath "//button[contains(@class, 'btn-primary') and contains(string(), 'Create Data Request')]"
+        Then I should see "Request blocked due to profanity" within 5 seconds
+
     Scenario Outline: Data request creator and Sysadmin can see a 'Close' button on the data request detail page for opened data requests
         Given "<User>" as the persona
         When I log in

--- a/test/features/datarequest_circumstances.feature
+++ b/test/features/datarequest_circumstances.feature
@@ -127,7 +127,7 @@ Feature: Datarequest-circumstances
         And I press the element with xpath "//a[contains(string(), 'Close')]"
         And I select "Open dataset already exists" from "close_circumstance"
         And I wait for 1 seconds
-        And I take a screenshot
+        And I take a debugging screenshot
         # Have to use JS to change the selected value as the behaving framework does not work with autocomplete dropdown
         Then I execute the script "$('#field-accepted_dataset_id').val($('#field-accepted_dataset_id option:eq(1)').attr('value'))"
         And I press the element with xpath "//button[contains(@class, 'btn-danger') and @name='close' and contains(string(), 'Close Data Request')]"


### PR DESCRIPTION
- Optionally block creating or updating data requests with expletives.