### PR TITLE
QOLDEV-638 throttle data request creation

### DIFF
--- a/test/features/comments.feature
+++ b/test/features/comments.feature
@@ -3,7 +3,7 @@ Feature: Comments
 
     @comment-add
     Scenario: When a logged-in user submits a comment on a Data Request the comment should then be visible on the Comments tab of the Data Request
-        Given "CKANUser" as the persona
+        Given "TestOrgMember" as the persona
         When I log in
         And I create a datarequest
         And I go to data request "$last_generated_title" comments

--- a/test/features/datarequest.feature
+++ b/test/features/datarequest.feature
@@ -125,3 +125,15 @@ Feature: Datarequest
         When I go to the "test_org_editor" profile page
         And I press the element with xpath "//ul[contains(@class, 'nav-tabs')]//a[contains(string(), 'Data Requests')]"
         Then I should see "No data requests found"
+
+    Scenario: An unprivileged user who tries to create multiple data requests close together should see an error
+        Given "CKANUser" as the persona
+        When I log in
+        And I create a datarequest
+        And I go to the data requests page
+        And I press "Add Data Request"
+        And I fill in title with random text
+        And I fill in "description" with "Test throttling"
+        And I press the element with xpath "//button[contains(@class, 'btn-primary')]"
+        Then I should see "Too many requests submitted, please wait"
+


### PR DESCRIPTION
- Restrict unprivileged accounts to creating one data request every five minutes. Increase the delay if they continue to attempt it.