### PR TITLE
QOLDEV-1011 update Selenium and Splinter to patch security vulnerability

### DIFF
--- a/bin/init-ext.sh
+++ b/bin/init-ext.sh
@@ -41,6 +41,9 @@ for extension in . `ls -d $SRC_DIR/ckanext-*`; do
     install_requirements $extension requirements pip-requirements
 done
 pip install -e .
+# force override of Splinter version to handle newer Selenium
+pip install "splinter>0.20"
+
 installed_name=$(grep '^\s*name=' setup.py |sed "s|[^']*'\([-a-zA-Z0-9]*\)'.*|\1|")
 
 # Validate that the extension was installed correctly.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -10,6 +10,6 @@ progressbar==2.5
 pytest-ckan
 python-magic==0.4.18
 requests
-selenium<4.16
+selenium<4.27
 six>=1.15.0
 xlrd==1.2.0

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -10,6 +10,6 @@ progressbar==2.5
 pytest-ckan
 python-magic==0.4.18
 requests
-selenium<4.10
+selenium<4.16
 six>=1.15.0
 xlrd==1.2.0


### PR DESCRIPTION
This introduces a conflict, since Behaving wants an older Splinter version, but forcing the new one does still seem to work.