### PR TITLE
[QOLSVC-9308] pass search facet data through to the listing pages

### DIFF
--- a/ckanext/datarequests/templates/datarequests/index.html
+++ b/ckanext/datarequests/templates/datarequests/index.html
@@ -19,6 +19,6 @@
 {% block secondary_content %}
   {{ super() }}
   {% for facet in facet_titles %}
-    {{ h.snippet('snippets/facet_list.html', title=facet_titles[facet], name=facet) }}
+    {{ h.snippet('snippets/facet_list.html', title=facet_titles[facet], name=facet, search_facets=search_facets) }}
   {% endfor %}
 {% endblock %}

--- a/ckanext/datarequests/templates/organization/datarequests.html
+++ b/ckanext/datarequests/templates/organization/datarequests.html
@@ -17,6 +17,6 @@
 {% block secondary_content %}
   {{ super() }}
   {% for facet in facet_titles %}
-    {{ h.snippet('snippets/facet_list.html', title=facet_titles[facet], name=facet, extras={'id': group_dict.name}) }}
+    {{ h.snippet('snippets/facet_list.html', title=facet_titles[facet], name=facet, extras={'id': group_dict.name}, search_facets=search_facets) }}
   {% endfor %}
 {% endblock %}

--- a/ckanext/datarequests/templates/user/datarequests.html
+++ b/ckanext/datarequests/templates/user/datarequests.html
@@ -13,6 +13,6 @@
 {% block secondary_content %}
   {{ super() }}
   {% for facet in facet_titles %}
-    {{ h.snippet('snippets/facet_list.html', title=facet_titles[facet], name=facet, extras={'id': user.name}) }}
+    {{ h.snippet('snippets/facet_list.html', title=facet_titles[facet], name=facet, extras={'id': user.name}, search_facets=search_facets) }}
   {% endfor %}
 {% endblock %}

--- a/test/features/datarequest.feature
+++ b/test/features/datarequest.feature
@@ -6,6 +6,7 @@ Feature: Datarequest
         Given "Unauthenticated" as the persona
         When I go to the data requests page
         Then the browser's URL should contain "/datarequest"
+        And I should see an element with xpath "//span[contains(@class, 'item-label') and string() = 'Open']"
         And I should not see an element with xpath "//a[contains(translate(string(), 'DR', 'dr'), 'Add data request')]"
 
     @unauthenticated
@@ -15,6 +16,7 @@ Feature: Datarequest
         And I click the link with text that contains "Test Organisation"
         And I press the element with xpath "//ul[contains(@class, 'nav-tabs')]//a[contains(string(), 'Data Requests')]"
         Then the browser's URL should contain "/organization/datarequest"
+        And I should see an element with xpath "//span[contains(@class, 'item-label') and string() = 'Open']"
         And I should see an element with xpath "//input[contains(@aria-label, 'Search Data Requests')]"
         And I should see an element with xpath "//ol[contains(@class, 'breadcrumb')]//a[contains(@href, '/organization')]"
         And I should see an element with xpath "//ol[contains(@class, 'breadcrumb')]//a[contains(@href, '/organization/') and contains(string(), 'Test Organisation')]"
@@ -25,6 +27,7 @@ Feature: Datarequest
         And I go to the "ckan_user" profile page
         And I press the element with xpath "//ul[contains(@class, 'nav-tabs')]//a[contains(string(), 'Data Requests')]"
         Then the browser's URL should contain "/user/datarequest"
+        And I should see an element with xpath "//span[contains(@class, 'item-label') and string() = 'Open']"
         And I should see an element with xpath "//input[contains(@aria-label, 'Search Data Requests')]"
         And I should see an element with xpath "//ol[contains(@class, 'breadcrumb')]//a[contains(@href, '/user') and contains(string(), 'Users')]"
         And I should see an element with xpath "//ol[contains(@class, 'breadcrumb')]//a[contains(@href, '/user/') and contains(string(), 'CKAN User')]"


### PR DESCRIPTION
- This was overlooked in the QOLDEV-327 CKAN 2.10 migration